### PR TITLE
Update README for SilverStripe 6 requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 A simple Bootstrap-style Card for Silverstripe Elemental. Intended for use with Elemental Grid.
 
 ![CI](https://github.com/dynamic/silverstripe-elemental-card/workflows/CI/badge.svg)
-[![codecov](https://codecov.io/gh/dynamic/silverstripe-elemental-card/branch/master/graph/badge.svg)](https://codecov.io/gh/dynamic/silverstripe-elemental-card)
 
 [![Latest Stable Version](https://poser.pugx.org/dynamic/silverstripe-elemental-card/v/stable)](https://packagist.org/packages/dynamic/silverstripe-elemental-card)
 [![Total Downloads](https://poser.pugx.org/dynamic/silverstripe-elemental-card/downloads)](https://packagist.org/packages/dynamic/silverstripe-elemental-card)
@@ -26,11 +25,25 @@ See [License](LICENSE.md)
 
 ## Usage
 
-A simple Bootstrap-style Card for Silverstripe Elemental. Intended for use with Elemental Grid.
+Elemental Card provides a flexible card component for displaying content with an optional image and link. Each card can include:
+
+- **Title** - The card heading
+- **Content** - HTML content for the card body/description
+- **Image** - An optional image that enhances the card
+- **Link** - An optional call-to-action link using SilverStripe LinkField, supporting internal pages, external URLs, email links, and more
+
+Cards are perfect for:
+- Feature highlights
+- Team member profiles  
+- Product or service showcases
+- News or blog post teasers
+- Call-to-action blocks
+
+When used with [Elemental Grid](https://github.com/dynamic/silverstripe-elemental-grid), you can create responsive card layouts with multiple cards per row.
 
 ### Template Notes
 
-The default templates are based off [Bootstrap 5](https://getbootstrap.com/) card component.
+The default templates are based on the [Bootstrap 5](https://getbootstrap.com/) card component, making it easy to integrate with Bootstrap-based themes. You can override the templates in your own theme to match your design system.
 
 ## Upgrading from version 2
 


### PR DESCRIPTION
This PR updates the README to reflect the new requirements for SilverStripe 6 compatibility:

- Updated requirements section to specify SilverStripe ^6.0, Elemental ^6.0, and LinkField ^5.0
- Added upgrade notes for version 2 to version 3, explaining the LinkField v5 changes where `ElementLink` moved from a `DBLink` database field to a `has_one` relationship with the `Link` model

These changes align with the recent dependency updates made in PR #10.