### PR TITLE
Set default Position to Top for ElementCard

### DIFF
--- a/src/Element/ElementCard.php
+++ b/src/Element/ElementCard.php
@@ -57,7 +57,7 @@ class ElementCard extends BaseElement
      */
     private static array $db = [
         'Content' => 'HTMLText',
-        'Position' => 'Enum("Left, Right, Top", "Left")',
+        'Position' => 'Enum("Left, Right, Top", "Top")',
     ];
 
     /**


### PR DESCRIPTION
## Overview
This PR changes the default value for the `Position` field from "Left" to "Top" in the ElementCard element.

## Changes
- Updated `ElementCard::$db['Position']` enum default from "Left" to "Top"

## Rationale
Setting the default position to "Top" provides a better default layout, as the description already notes: "Image will display on top at smaller breakpoints." This makes the default behavior consistent across all screen sizes.

## Testing
- Verified the change compiles correctly
- Existing tests continue to pass