### PR TITLE
FIX SS6 template compatibility - remove $TitleTag references

### DIFF
--- a/templates/Dynamic/Elements/Card/Elements/ElementCard.ss
+++ b/templates/Dynamic/Elements/Card/Elements/ElementCard.ss
@@ -12,7 +12,7 @@
         <div class="<% if $Position != 'Top' %> col-lg-5<% end_if %><% if $Position == 'Right' %> order-md-first<% end_if %>">
             <div class="card-body h-100 d-flex align-items-center">
                 <div>
-                    <% if $Title && $ShowTitle %><$TitleTag class="element__title $TitleSizeClass">$Title</$TitleTag><% end_if %>
+                    <% if $Title && $ShowTitle %><h2 class="element__title">$Title</h2><% end_if %>
                     <% if $Content %><div class="card-text">$Content</div><% end_if %>
                     <% if $ElementLink %><p><a href="$ElementLink.URL" class="btn btn-primary" title="$ElementLink.Title"<% if $ElementLink.OpenInNew %> target="_blank" rel="noopener noreferrer"<% end_if %>>$ElementLink.Title</a></p><% end_if %>
                 </div>


### PR DESCRIPTION
## Summary
Fixes ElementCard template for SilverStripe 6 compatibility by removing incompatible `$TitleTag` and `$TitleSizeClass` variables from `wedevelopnl/silverstripe-elemental-grid` package.

## Changes
- Removed `<$TitleTag class="element__title $TitleSizeClass">$Title</$TitleTag>` 
- Replaced with standard `<h2 class="element__title">$Title</h2>`

## Reason
The `$TitleTag` and `$TitleSizeClass` variables come from the `wedevelopnl/silverstripe-elemental-grid` package which is not yet compatible with SilverStripe 6. Using these variables caused broken HTML output showing raw template syntax on the frontend.

## Testing
- Verified card element displays correctly on frontend
- Screenshot: template-preview-fixed.png showing corrected layout without broken HTML

## Related
- Part of SilverStripe 6 upgrade effort
- Complements fixes in silverstripe-elemental-templates PR #33