### PR TITLE
REFACTOR: Remove getType() override to allow extensibility

### DIFF
--- a/src/Element/ElementCard.php
+++ b/src/Element/ElementCard.php
@@ -153,12 +153,4 @@ class ElementCard extends BaseElement
     {
         return DBField::create_field('HTMLText', $this->HTML)->Summary(20);
     }
-
-    /**
-     * @return string
-     */
-    public function getType(): string
-    {
-        return _t(__CLASS__ . '.BlockType', 'Card');
-    }
 }


### PR DESCRIPTION
## Summary

Remove the `getType()` method override so the element inherits `BaseElement::getType()` which uses `i18n_singular_name()`. This allows sites to customize the element's display name via extensions by setting `$singular_name`.

## Changes

- Removed the `getType()` method from `ElementCard`

## Rationale

The base `BaseElement::getType()` implementation already uses `$this->i18n_singular_name()`:

```php
public function getType()
{
    $default = $this->i18n_singular_name() ?: 'Block';
    return _t(static::class . '.BlockType', $default);
}
```

By removing the override, extensions can now customize the display name in the CMS element picker by simply setting `$singular_name`, without needing to override the entire method.

Fixes #20

Related: dynamic/silverstripe-essentials-tools#68