### PR TITLE
Merge SS5 branch (2) into SS6 branch (3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,5 +9,3 @@ jobs:
   ci:
     name: CI
     uses: silverstripe/gha-ci/.github/workflows/ci.yml@v1
-    with:
-      phpcoverage: true

--- a/composer.json
+++ b/composer.json
@@ -37,10 +37,5 @@
             "silverstripe/vendor-plugin": true
         },
         "process-timeout": 600
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "2.x-dev"
-        }
     }
 }

--- a/src/Element/ElementCard.php
+++ b/src/Element/ElementCard.php
@@ -153,12 +153,4 @@ class ElementCard extends BaseElement
     {
         return DBField::create_field('HTMLText', $this->HTML)->Summary(20);
     }
-
-    /**
-     * @return string
-     */
-    public function getType(): string
-    {
-        return _t(__CLASS__ . '.BlockType', 'Card');
-    }
 }


### PR DESCRIPTION
## Summary

Merge the SS5 branch into the SS6 branch to bring forward the `getType()` refactor changes.

## Changes from SS5 branch

- Removed `getType()` method override to allow extensibility via `$singular_name`

## Related

- Original SS5 PR: #21
- Parent issue: dynamic/silverstripe-essentials-tools#68