### PR TITLE
chore: rename phpstan.neon → phpstan.neon.dist, add baseline

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -19,6 +19,12 @@ parameters:
 			path: src/Element/ElementCard.php
 
 		-
+			message: '#^First argument passed to _t\(\) must have exactly one period\.$#'
+			identifier: translation.key
+			count: 1
+			path: src/Element/ElementCard.php
+
+		-
 			message: '#^Static property Dynamic\\Elements\\Card\\Elements\\ElementCard\:\:\$cascade_deletes is never read, only written\.$#'
 			identifier: property.onlyWritten
 			count: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,79 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Call to an undefined method SilverStripe\\Forms\\FormField\:\:setFolderName\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Element/ElementCard.php
+
+		-
+			message: '#^Call to an undefined method SilverStripe\\Forms\\FormField\:\:setRows\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Element/ElementCard.php
+
+		-
+			message: '#^Call to an undefined method SilverStripe\\ORM\\FieldType\\DBField\:\:Summary\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/Element/ElementCard.php
+
+		-
+			message: '#^Static property Dynamic\\Elements\\Card\\Elements\\ElementCard\:\:\$cascade_deletes is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: src/Element/ElementCard.php
+
+		-
+			message: '#^Static property Dynamic\\Elements\\Card\\Elements\\ElementCard\:\:\$cascade_duplicates is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: src/Element/ElementCard.php
+
+		-
+			message: '#^Static property Dynamic\\Elements\\Card\\Elements\\ElementCard\:\:\$db is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: src/Element/ElementCard.php
+
+		-
+			message: '#^Static property Dynamic\\Elements\\Card\\Elements\\ElementCard\:\:\$description is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: src/Element/ElementCard.php
+
+		-
+			message: '#^Static property Dynamic\\Elements\\Card\\Elements\\ElementCard\:\:\$has_one is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: src/Element/ElementCard.php
+
+		-
+			message: '#^Static property Dynamic\\Elements\\Card\\Elements\\ElementCard\:\:\$icon is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: src/Element/ElementCard.php
+
+		-
+			message: '#^Static property Dynamic\\Elements\\Card\\Elements\\ElementCard\:\:\$owns is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: src/Element/ElementCard.php
+
+		-
+			message: '#^Static property Dynamic\\Elements\\Card\\Elements\\ElementCard\:\:\$plural_name is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: src/Element/ElementCard.php
+
+		-
+			message: '#^Static property Dynamic\\Elements\\Card\\Elements\\ElementCard\:\:\$singular_name is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: src/Element/ElementCard.php
+
+		-
+			message: '#^Static property Dynamic\\Elements\\Card\\Elements\\ElementCard\:\:\$table_name is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: src/Element/ElementCard.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,0 @@
-parameters:
-  level: 4
-  treatPhpDocTypesAsCertain: false
-  paths:
-    - src
-  ignoreErrors:
-    # SilverStripe specific ignores can be added here if needed

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,8 @@
+includes:
+  - phpstan-baseline.neon
+
+parameters:
+  level: 4
+  treatPhpDocTypesAsCertain: false
+  paths:
+    - src

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,5 +4,6 @@ includes:
 parameters:
   level: 4
   treatPhpDocTypesAsCertain: false
+  reportUnmatchedIgnoredErrors: false
   paths:
     - src

--- a/src/Element/ElementCard.php
+++ b/src/Element/ElementCard.php
@@ -118,11 +118,9 @@ class ElementCard extends BaseElement
     public function getCMSFields(): FieldList
     {
         $this->beforeUpdateCMSFields(function (FieldList $fields) {
-            // @phpstan-ignore-next-line
             $fields->dataFieldByName('Content')
                 ->setRows(8);
 
-            // @phpstan-ignore-next-line
             $fields->dataFieldByName('Image')
                 ->setFolderName('Uploads/Elements/Card');
             $fields->insertBefore('Position', $fields->dataFieldByName('Image'));


### PR DESCRIPTION
## Summary

- Renames `phpstan.neon` to `phpstan.neon.dist` so the `silverstripe/gha-ci` shared workflow auto-discovers it
- Removes two stale `@phpstan-ignore-next-line` comments in `ElementCard.php` — the ignore targets had shifted one line down due to method chaining; the actual `setRows()` and `setFolderName()` errors are covered by the baseline
- Adds `phpstan-baseline.neon` to capture pre-existing errors so CI starts green

Closes #23

## Test plan

- [ ] CI phpstan step appears and passes in the job matrix
- [ ] No regression on `setRows()` / `setFolderName()` — both handled by baseline